### PR TITLE
Update npm and GitHub registry configurations

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,13 @@
 # .npmrc
-@npm-registry:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
-registry=https://npm.pkg.github.com/
+# 공식 npm 레지스트리에서 패키지를 가져오도록 설정
+registry=https://registry.npmjs.org/
 
-# access 설정 추가
+# GitHub Packages에 발행되는 패키지들은 이 레지스트리에서 가져오도록 설정
+# 예시: @npm-registry 스코프의 패키지
+@npm-registry:registry=https://npm.pkg.github.com/
+
+# GitHub Packages 인증 설정
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+
+# 모든 패키지를 public으로 발행하도록 설정
 access=public


### PR DESCRIPTION
```
- Updated `.npmrc` to include official npm and GitHub Packages registry settings.
- Configured all packages to be published as public.
- Added comments for authentication-related settings.
- Modified `release` script registry configuration in `package.json`.
- Updated GitHub Actions to verify the path for the `pnpm-lock.yaml`.
- Upgraded `pnpm` version to 9 for compatibility improvements.
```