### PR TITLE
Update project configuration for GitHub Actions and npm registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,4 +62,5 @@ jobs:
           title: "Release: Version Packages"
           commit: "Release: Version Packages"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes the following updates:

- **GitHub Actions:**  
  Added and updated environment variables, including `GITHUB_TOKEN`, to better align with deployment requirements.

- **.npmrc updates:**  
  - Configured to use both the official npm registry and GitHub Packages registry.  
  - Ensured all packages are published as `public`.  
  - Included comments for authentication settings.

- **package.json and GitHub Actions:**  
  - Modified `release` script to adjust registry configuration.  
  - Added a file path check to locate `pnpm-lock.yaml`.  
  - Updated `pnpm` version to 9 for greater consistency and compatibility.  

This enhances the deployment workflow and aligns configurations with updated project standards.