### PR TITLE
Update GitHub Actions to use updated syntax and pnpm setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,14 +51,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for Changes
+        id: changes
         run: |
           git status --porcelain
           if [[ $(git status --porcelain | grep "^M\|^A\|^D") ]]; then
-            echo "::set-output name=changes_exist::true"
+            echo "changes_exist=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=changes_exist::false"
+            echo "changes_exist=false" >> $GITHUB_OUTPUT
           fi
-        id: changes
 
       - name: Commit and Publish if Changes Exist
         if: steps.changes.outputs.changes_exist == 'true'


### PR DESCRIPTION
```
### Description

This pull request makes updates to the GitHub Actions configurations:

- Replaced the deprecated `::set-output` syntax with the modern `$GITHUB_OUTPUT` approach in `publish.yml`.
- Added pnpm setup step using `pnpm/action-setup@v3` with configuration set to version 9.

### Checklist
- [ ] Documentation updated, if applicable
- [ ] Tests added or updated, if applicable
- [ ] Code linted and formatted properly
```